### PR TITLE
Feature/add bypass unsubscribe management enabled

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -131,6 +131,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_bypass_unsubscribe_management(email)
     |> put_google_analytics(email)
     |> put_click_tracking(email)
+    |> put_subscription_tracking(email)
     |> put_ip_pool_name(email)
     |> put_custom_args(email)
   end
@@ -380,6 +381,17 @@ defmodule Bamboo.SendGridAdapter do
   end
 
   defp put_click_tracking(body, _), do: body
+
+  defp put_subscription_tracking(body, %Email{private: %{subscription_tracking_enabled: enabled}}) do
+    tracking_settings =
+      body
+      |> Map.get(:tracking_settings, %{})
+      |> Map.put(:subscription_tracking, %{enable: enabled, enable_text: enabled})
+
+    Map.put(body, :tracking_settings, tracking_settings)
+  end
+
+  defp put_subscription_tracking(body, _), do: body
 
   defp put_attachments(body, %Email{attachments: []}), do: body
 

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -128,6 +128,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_settings(config)
     |> put_asm_group_id(email)
     |> put_bypass_list_management(email)
+    |> put_bypass_unsubscribe_management(email)
     |> put_google_analytics(email)
     |> put_click_tracking(email)
     |> put_ip_pool_name(email)
@@ -339,6 +340,18 @@ defmodule Bamboo.SendGridAdapter do
   end
 
   defp put_bypass_list_management(body, _), do: body
+
+  defp put_bypass_unsubscribe_management(body, %Email{private: %{bypass_unsubscribe_management: enabled}})
+       when is_boolean(enabled) do
+    mail_settings =
+      body
+      |> Map.get(:mail_settings, %{})
+      |> Map.put(:bypass_unsubscribe_management, %{enable: enabled})
+
+    Map.put(body, :mail_settings, mail_settings)
+  end
+
+  defp put_bypass_unsubscribe_management(body, _), do: body
 
   defp put_google_analytics(body, %Email{
          private: %{google_analytics_enabled: enabled, google_analytics_utm_params: utm_params}

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -25,6 +25,7 @@ defmodule Bamboo.SendGridHelper do
   @ip_pool_name_field :ip_pool_name
   @custom_args :custom_args
   @click_tracking_enabled :click_tracking_enabled
+  @subscription_tracking_enabled :subscription_tracking_enabled
 
   @doc """
   Specify the template for SendGrid to use for the context of the substitution
@@ -243,6 +244,27 @@ defmodule Bamboo.SendGridHelper do
 
   def with_click_tracking(_email, _enabled) do
     raise "expected with_click_tracking enabled parameter to be a boolean"
+  end
+
+  @doc """
+  Instruct SendGrid to enable or disable Subscription Tracking for a particular email.
+
+  Read more about SendGrid click tracking [here](https://docs.sendgrid.com/ui/account-and-settings/tracking#subscription-tracking)
+
+  ## Example
+
+      email
+      |> with_subscription_tracking(true)
+
+      email
+      |> with_subscription_tracking(false)
+  """
+  def with_subscription_tracking(email, enabled)
+      when is_boolean(enabled),
+      do: Email.put_private(email, @subscription_tracking_enabled, enabled)
+
+  def with_subscription_tracking(_email, _enabled) do
+    raise "expected with_subscription_tracking enabled parameter to be a boolean"
   end
 
   @doc """

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -16,6 +16,7 @@ defmodule Bamboo.SendGridHelper do
   @categories :categories
   @asm_group_id :asm_group_id
   @bypass_list_management :bypass_list_management
+  @bypass_unsubscribe_management :bypass_unsubscribe_management
   @google_analytics_enabled :google_analytics_enabled
   @google_analytics_utm_params :google_analytics_utm_params
   @additional_personalizations :additional_personalizations
@@ -167,6 +168,28 @@ defmodule Bamboo.SendGridHelper do
 
   def with_bypass_list_management(_email, enabled) do
     raise "expected bypass_list_management parameter to be a boolean, got #{enabled}"
+  end
+
+  @doc """
+  Instruct SendGrid to bypass unsubscribe list management for this email.
+
+  If enabled, SendGrid will ignore any email suppression (such as
+  unsubscriptions, bounces, spam filters) for this email. This is useful for
+  emails that all users must receive, such as Terms of Service updates, or
+  password resets.
+
+  ## Example
+
+      email
+      |> with_bypass_unsubscribe_management(true)
+  """
+  def with_bypass_unsubscribe_management(email, enabled) when is_boolean(enabled) do
+    email
+    |> Email.put_private(@bypass_unsubscribe_management, enabled)
+  end
+
+  def with_bypass_unsubscribe_management(_email, enabled) do
+    raise "expected bypass_unsubscribe_management parameter to be a boolean, got #{enabled}"
   end
 
   @doc """

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -277,6 +277,22 @@ defmodule Bamboo.SendGridAdapterTest do
     assert params["mail_settings"]["bypass_list_management"]["enable"] == true
   end
 
+
+  test "deliver/2 correctly handles a bypass_unsubscribe_management" do
+    email =
+      new_email(
+        from: {"From", "from@foo.com"},
+        subject: "My Subject"
+      )
+
+    email
+    |> Bamboo.SendGridHelper.with_bypass_unsubscribe_management(true)
+    |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["mail_settings"]["bypass_unsubscribe_management"]["enable"] == true
+  end
+
   test "deliver/2 correctly handles with_google_analytics that's enabled with no utm_params" do
     email =
       new_email(

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -367,6 +367,38 @@ defmodule Bamboo.SendGridAdapterTest do
     assert params["tracking_settings"]["click_tracking"]["enable_text"] == false
   end
 
+  test "deliver/2 correctly handles when with_subscription_tracking is enabled" do
+    email =
+      new_email(
+        from: {"From", "from@foo.com"},
+        subject: "My Subject"
+      )
+
+    email
+    |> Bamboo.SendGridHelper.with_subscription_tracking(true)
+    |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["tracking_settings"]["subscription_tracking"]["enable"] == true
+    assert params["tracking_settings"]["subscription_tracking"]["enable_text"] == true
+  end
+
+  test "deliver/2 correctly handles when with_subscription_tracking is disabled" do
+    email =
+      new_email(
+        from: {"From", "from@foo.com"},
+        subject: "My Subject"
+      )
+
+    email
+    |> Bamboo.SendGridHelper.with_subscription_tracking(false)
+    |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["tracking_settings"]["subscription_tracking"]["enable"] == false
+    assert params["tracking_settings"]["subscription_tracking"]["enable_text"] == false
+  end
+
   test "deliver/2 correctly handles a sendgrid_send_at timestamp" do
     email =
       new_email(

--- a/test/lib/bamboo/adapters/send_grid_helper_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_helper_test.exs
@@ -151,6 +151,18 @@ defmodule Bamboo.SendGridHelperTest do
     end
   end
 
+
+  test "with_bypass_unsubscribe_management/2 adds the correct property", %{email: email} do
+    email = email |> with_bypass_unsubscribe_management(true)
+    assert email.private[:bypass_unsubscribe_management] == true
+  end
+
+  test "with_bypass_unsubscribe_management/2 raises on non-boolean parameter", %{email: email} do
+    assert_raise RuntimeError, fn ->
+      email |> with_bypass_unsubscribe_management(1)
+    end
+  end
+
   test "with_google_analytics/3 with utm_params", %{email: email} do
     utm_params = %{
       utm_source: "source",

--- a/test/lib/bamboo/adapters/send_grid_helper_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_helper_test.exs
@@ -201,6 +201,24 @@ defmodule Bamboo.SendGridHelperTest do
     end
   end
 
+  test "with_subscription_tracking/2 with enabled set to true", %{email: email} do
+    email = with_subscription_tracking(email, true)
+
+    assert email.private[:subscription_tracking_enabled] == true
+  end
+
+  test "with_subscription_tracking/2 with enabled set false", %{email: email} do
+    email = with_subscription_tracking(email, false)
+
+    assert email.private[:subscription_tracking_enabled] == false
+  end
+
+  test "with_subscription_tracking/2 raises on non-boolean enabled parameter", %{email: email} do
+    assert_raise RuntimeError, fn ->
+      with_subscription_tracking(email, 1)
+    end
+  end
+
   describe "with_send_at/2" do
     test "adds the correct property for a DateTime input", %{email: email} do
       {:ok, datetime, _} = DateTime.from_iso8601("2020-01-31T15:46:00Z")


### PR DESCRIPTION
Adding in new setting to send `bypass_unsubscribe_management` and tests to go with.
I forgot to pull main when I did the initial branch and then rebased main on top of the branch, so now it wants to add the code I already did? So, this PR has both of the new features I just added for some reason.